### PR TITLE
Support for using a file containing the app settings/connection strings instead of adding inline

### DIFF
--- a/AzureAppServiceSetAppSettings/Tasks/AppSettings/ApplyAppSettings.ps1
+++ b/AzureAppServiceSetAppSettings/Tasks/AppSettings/ApplyAppSettings.ps1
@@ -12,8 +12,14 @@ param(
     [String] [Parameter(Mandatory = $false)]
     $Slot = "",
 
-    [String] [Parameter(Mandatory = $true)]
-    $AppSettings
+    [String] [Parameter(Mandatory = $false)]
+    $InputType,
+
+    [String] [Parameter(Mandatory = $true, ParameterSetName = "Multiline")]
+    $AppSettings,
+
+    [String] [Parameter(Mandatory = $true, ParameterSetName = "Filepath")]
+    $AppSettingsFilePath
 )
 
 # For more information on the VSTS Task SDK:
@@ -26,10 +32,12 @@ If ($Slot -eq "") {
     $Slot = "production"
 }
 
-Write-Host("=== START ===")
+Write-Host ("=== START ===")
+Write-Host ("Input type: " + $InputType)
 Write-Host ("Webapp: " + $WebAppName)
 Write-Host ("Slot: " + $Slot)
 Write-Host ("Appsettings: " + $AppSettings)
+Write-Host ("AppSettingsFilePath: " + $AppSettingsFilePath)
 
 $seperator = [Environment]::NewLine
 $splitOption = [System.StringSplitOptions]::RemoveEmptyEntries
@@ -48,9 +56,9 @@ foreach ($kvp in $appSettingList) {
 }
 
 foreach ($keyValue in $lines) {
-    $key,$val = $keyValue.Split("'", $splitOption)
-    $hash[$key.ToString().Replace("=","").Trim()] = $val
-    Write-Host ("Adding - Key: " + $key.Replace("=","")  + " Value: " + $val)
+    $key, $val = $keyValue.Split("'", $splitOption)
+    $hash[$key.ToString().Replace("=", "").Trim()] = $val
+    Write-Host ("Adding - Key: " + $key.Replace("=", "") + " Value: " + $val)
 }
 
 Set-AzureRMWebAppSlot -Name $WebAppName -ResourceGroupName $ResourceGroupName -Slot $Slot -AppSettings $hash

--- a/AzureAppServiceSetAppSettings/Tasks/AppSettings/ApplyAppSettings.ps1
+++ b/AzureAppServiceSetAppSettings/Tasks/AppSettings/ApplyAppSettings.ps1
@@ -15,10 +15,10 @@ param(
     [String] [Parameter(Mandatory = $false)]
     $InputType,
 
-    [String] [Parameter(Mandatory = $true, ParameterSetName = "Multiline")]
+    [String] [Parameter(Mandatory = $false)]
     $AppSettings,
 
-    [String] [Parameter(Mandatory = $true, ParameterSetName = "Filepath")]
+    [String] [Parameter(Mandatory = $false)]
     $AppSettingsFilePath
 )
 
@@ -33,11 +33,19 @@ If ($Slot -eq "") {
 }
 
 Write-Host ("=== START ===")
-Write-Host ("Input type: " + $InputType)
 Write-Host ("Webapp: " + $WebAppName)
 Write-Host ("Slot: " + $Slot)
+
+if ($InputType -eq "FilePath") { 
+    Write-Host ("AppSettingsFilePath: " + $AppSettingsFilePath)
+    if (!(Test-Path -LiteralPath $AppSettingsFilePath -PathType Leaf)) {
+        throw "File `"$AppSettingsFilePath`" could not be found"
+    }
+    $AppSettings = Get-Content -Path $AppSettingsFilePath -Raw
+}
+
 Write-Host ("Appsettings: " + $AppSettings)
-Write-Host ("AppSettingsFilePath: " + $AppSettingsFilePath)
+
 
 $seperator = [Environment]::NewLine
 $splitOption = [System.StringSplitOptions]::RemoveEmptyEntries

--- a/AzureAppServiceSetAppSettings/Tasks/AppSettings/task.json
+++ b/AzureAppServiceSetAppSettings/Tasks/AppSettings/task.json
@@ -59,6 +59,18 @@
             "helpMarkDown": "Select the slot to configure, or leave empty to use the default, production slot."
         },
         {
+            "name": "InputType",
+            "type": "radio",
+            "label": "Input Type",
+            "required": false,
+            "helpMarkDown": "Type of app settings pit: File Path or Multiline",
+            "defaultValue": "Multiline",
+            "options": {
+                "FilePath": "File Path",
+                "Multiline": "Multiline"
+            }
+        },
+        {
             "name": "AppSettings",
             "type": "multiLine",
             "label": "App Settings",
@@ -68,7 +80,17 @@
             "properties": {
                 "resizable": "true",
                 "rows": "20"
-            }
+            },
+            "visibleRule": "InputType = Multiline"
+        },
+        {
+            "name": "AppSettingsFilePath",
+            "type": "filePath",
+            "label": "App Settings File Path",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "File containing every App Setting on a seperated line. Key and value are seperated by = and the values enclosed by a singleqoute",
+            "visibleRule": "InputType = FilePath"
         }
     ],
     "dataSourceBindings": [{

--- a/AzureAppServiceSetAppSettings/Tasks/AppSettings/task.json
+++ b/AzureAppServiceSetAppSettings/Tasks/AppSettings/task.json
@@ -11,7 +11,7 @@
     ],
     "demands": ["azureps"],
     "version": {
-        "Major": "2",
+        "Major": "3",
         "Minor": "0",
         "Patch": "0"
     },
@@ -66,8 +66,8 @@
             "helpMarkDown": "Type of app settings pit: File Path or Multiline",
             "defaultValue": "Multiline",
             "options": {
-                "FilePath": "File Path",
-                "Multiline": "Multiline"
+                "Multiline": "Multiline",
+                "FilePath": "File Path"
             }
         },
         {
@@ -75,7 +75,7 @@
             "type": "multiLine",
             "label": "App Settings",
             "defaultValue": "key1='value1'\nkey2='value2'",
-            "required": true,
+            "required": false,
             "helpMarkDown": "Add every App Setting on a seperated line. Key and value are seperated by = and the values enclosed by a singleqoute",
             "properties": {
                 "resizable": "true",

--- a/AzureAppServiceSetAppSettings/Tasks/ConnectionStrings/task.json
+++ b/AzureAppServiceSetAppSettings/Tasks/ConnectionStrings/task.json
@@ -9,15 +9,18 @@
     "visibility": [
         "Release"
     ],
-    "demands": ["azureps"],
+    "demands": [
+        "azureps"
+    ],
     "version": {
-        "Major": "2",
+        "Major": "3",
         "Minor": "0",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.95.0",
     "instanceNameFormat": "Set Connection Strings: $(pickList)",
-    "inputs": [{
+    "inputs": [
+        {
             "name": "ConnectedServiceName",
             "type": "connectedService:AzureRM",
             "label": "AzureRM Subscription",
@@ -59,19 +62,42 @@
             "helpMarkDown": "Select the slot to configure, or leave empty to use the default, production slot."
         },
         {
+            "name": "InputType",
+            "type": "radio",
+            "label": "Input Type",
+            "required": false,
+            "helpMarkDown": "Type of app settings pit: File Path or Multiline",
+            "defaultValue": "Multiline",
+            "options": {
+                "Multiline": "Multiline",
+                "FilePath": "File Path"
+            }
+        },
+        {
             "name": "ConnectionStrings",
             "type": "multiLine",
             "label": "Connection Strings",
             "defaultValue": "key1='value1''type1'\nkey2='value2''type2'",
-            "required": true,
-            "helpMarkDown": "Add every Connection String on a seperated line. Key and value are seperated by = and the values and Connection String types enclosed by a singleqoute",
+            "required": false,
+            "helpMarkDown": "Add every Connection String on a seperated line. Key and value are seperated by = and the values and Connection String types enclosed by a singlequote",
             "properties": {
                 "resizable": "true",
                 "rows": "20"
-            }
+            },
+            "visibleRule": "InputType = Multiline"
+        },
+        {
+            "name": "ConnectionStringsFilePath",
+            "type": "filePath",
+            "label": "Connection Strings File Path",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "File containing every Connection String on a seperated line. Key and value are seperated by = and the values and Connection String types enclosed by a singlequote",
+            "visibleRule": "InputType = FilePath"
         }
     ],
-    "dataSourceBindings": [{
+    "dataSourceBindings": [
+        {
             "target": "WebAppName",
             "endpointId": "$(ConnectedServiceName)",
             "dataSourceName": "AzureRMWebAppNames"

--- a/AzureAppServiceSetAppSettings/Tasks/ConnectionStrings/task.json
+++ b/AzureAppServiceSetAppSettings/Tasks/ConnectionStrings/task.json
@@ -9,9 +9,7 @@
     "visibility": [
         "Release"
     ],
-    "demands": [
-        "azureps"
-    ],
+    "demands": ["azureps"],
     "version": {
         "Major": "3",
         "Minor": "0",
@@ -19,8 +17,7 @@
     },
     "minimumAgentVersion": "1.95.0",
     "instanceNameFormat": "Set Connection Strings: $(pickList)",
-    "inputs": [
-        {
+    "inputs": [{
             "name": "ConnectedServiceName",
             "type": "connectedService:AzureRM",
             "label": "AzureRM Subscription",
@@ -96,8 +93,7 @@
             "visibleRule": "InputType = FilePath"
         }
     ],
-    "dataSourceBindings": [
-        {
+    "dataSourceBindings": [{
             "target": "WebAppName",
             "endpointId": "$(ConnectedServiceName)",
             "dataSourceName": "AzureRMWebAppNames"

--- a/AzureAppServiceSetAppSettings/vss-extension.json
+++ b/AzureAppServiceSetAppSettings/vss-extension.json
@@ -1,13 +1,13 @@
 {
     "manifestVersion": 1,
     "id": "AzureAppServiceSetAppSettings",
-    "version": "2.0.0",
+    "version": "3.0.0",
     "name": "Azure App Service: Set App settings",
     "publisher": "hboelman",
     "description": "Add settings to the App Settings of an Azure App Service.",
     "targets": [{
-        "id": "Microsoft.VisualStudio.Services"
-    }],
+            "id": "Microsoft.VisualStudio.Services"
+        }],
     "demands": [
         "api-version/3.0",
         "contribution/ms.vss-dashboards-web.widget-catalog"
@@ -31,8 +31,8 @@
         "Public"
     ],
     "screenshots": [{
-        "path": "images/screen1.JPG"
-    }],
+            "path": "images/screen1.JPG"
+        }],
     "content": {
         "details": {
             "path": "overview.md"


### PR DESCRIPTION
This Pull Request adds support for using a file in the Release process which contains either the App Settings or Connection Strings that will then be set on the App Service in the same way as they are currently.