### PR TITLE
Changed execution from AzurePowershell to Powershell to fix on-prem build issues.

### DIFF
--- a/AzureAppServiceSetAppSettings/Tasks/AppSettings/task.json
+++ b/AzureAppServiceSetAppSettings/Tasks/AppSettings/task.json
@@ -96,7 +96,7 @@
         }
     ],
     "execution": {
-        "AzurePowerShell": {
+        "PowerShell": {
             "target": "ApplyAppSettings.ps1"
         }
     }

--- a/AzureAppServiceSetAppSettings/Tasks/ConnectionStrings/task.json
+++ b/AzureAppServiceSetAppSettings/Tasks/ConnectionStrings/task.json
@@ -96,7 +96,7 @@
         }
     ],
     "execution": {
-        "AzurePowerShell": {
+        "PowerShell": {
             "target": "ApplyConnectionStrings.ps1"
         }
     }


### PR DESCRIPTION
We just moved to on-prem build agents and noticed right away that something was off. During imports (even before azure-login in the log) I received:

> Error in TypeData "Microsoft.Azure.Commands.Common.Authentication.Abstractions.IAzureContextContainer": The TypeConverter was ignored because it already occurs.
> ...

I resolved them with this patch, so I'm hoping you are willing to accept it.